### PR TITLE
Formats code to WordPress Standards and adds option for disabling file edits

### DIFF
--- a/wordpress-hack-without-plugin.php
+++ b/wordpress-hack-without-plugin.php
@@ -1,102 +1,136 @@
-//removing failed error message
-
-function login_error_override()
-{
-    return 'Incorrect login details.';
+<?php
+/**
+ * Remove failed error message.
+ */
+function login_error_override() {
+	return 'Incorrect login details.';
 }
-add_filter('login_errors', 'login_error_override');
+add_filter( 'login_errors', 'login_error_override' );
 
-//removing wordpress login page shake
-
+/**
+ * Remove wordpress login page shake.
+ */
 function my_login_head() {
-remove_action('login_head', 'wp_shake_js', 12);
+	remove_action( 'login_head', 'wp_shake_js', 12 );
 }
-add_action('login_head', 'my_login_head');
+add_action( 'login_head', 'my_login_head' );
 
-//removing menus in users dashboard
-
-add_action( 'admin_menu', 'remove_menus' );
-function remove_menus(){
-	if ( !current_user_can( 'manage_options' ) ) {
+/**
+ * Remove menu in users dashboard.
+ */
+function remove_menus() {
+	if ( ! current_user_can( 'manage_options' ) ) {
 		remove_menu_page( 'tools.php' );
 		remove_menu_page( 'options-general.php' );
 	}
 }
+add_action( 'admin_menu', 'remove_menus' );
 
-//removing pressthis widget in user dashboard
-
-add_action('wp_dashboard_setup', 'remove_dashboard_widgets' );
+/**
+ * Removing pressthis widget in user dashboard
+ */
 function remove_dashboard_widgets() {
 	global $wp_meta_boxes;
-	unset($wp_meta_boxes['dashboard']['side']['core']['dashboard_quick_press']);
+	unset( $wp_meta_boxes['dashboard']['side']['core']['dashboard_quick_press'] );
 }
+add_action( 'wp_dashboard_setup', 'remove_dashboard_widgets' );
 
-//removing admin dashboard footer text (change "add your text here" to your input value)
-
-function remove_footer_admin () {
-    echo "Add your text here";
-} 
-
-add_filter('admin_footer_text', 'remove_footer_admin'); 
-
-//disabling remember me option
-
-add_action('login_head', 'do_not_remember_me');
-function do_not_remember_me()
-{
-echo '<style type="text/css">.forgetmenot { display:none; }</style>';
+/**
+ * Removing admin dashboard footer text
+ *
+ * Change "add your text here" to your input value.
+ */
+function remove_footer_admin() {
+	echo "Add your text here";
 }
+add_filter( 'admin_footer_text', 'remove_footer_admin' );
 
-//removing wordpress version number from rss,header
+/**
+ * Disable remember me option
+ */
+function do_not_remember_me() {
+	echo '<style type="text/css">.forgetmenot { display:none; }</style>';
+}
+add_action( 'login_head', 'do_not_remember_me' );
 
+/**
+ * Removing wordpress version number from rss,header.
+ */
 function namdi_remove_version() {
-return '';
+	return '';
 }
-add_filter('the_generator', 'namdi_remove_version');
+add_filter( 'the_generator', 'namdi_remove_version' );
 
-//Hide admin footer from admin
+/**
+ * Hide admin footer from admin.
+ */
+function change_footer_admin() {
+	return ' ';
+}
+add_filter( 'admin_footer_text', 'change_footer_admin', 9999 );
 
-function change_footer_admin () {return ' ';}
-add_filter('admin_footer_text', 'change_footer_admin', 9999);
-function change_footer_version() {return ' ';}
-add_filter( 'update_footer', 'change_footer_version', 9999);
+/**
+ * Hide admin footer version.
+ */
+function change_footer_version() {
+	return '';
+}
+add_filter( 'update_footer', 'change_footer_version', 9999 );
 
-// Remove WP Version From Styles	
+/**
+ * Remove WP Version From Styles.
+ */
 add_filter( 'style_loader_src', 'sdt_remove_ver_css_js', 9999 );
 
 // Remove WP Version From Scripts
 add_filter( 'script_loader_src', 'sdt_remove_ver_css_js', 9999 );
 
-// Function to remove version numbers
+/**
+ * Function to remove version numbers.
+ */
 function sdt_remove_ver_css_js( $src ) {
-	if ( strpos( $src, 'ver=' ) )
+	if ( strpos( $src, 'ver=' ) ) {
 		$src = remove_query_arg( 'ver', $src );
+	}
+
 	return $src;
 }
 
-//changing wp login logo url 
-
+/**
+ * Changing wp login logo url.
+ */
 function my_login_logo_url() {
-return get_bloginfo( 'url' );
+	return get_bloginfo( 'url' );
 }
 add_filter( 'login_headerurl', 'my_login_logo_url' );
 
+/**
+ * Update logo url title.
+ */
 function my_login_logo_url_title() {
-return 'add_your_text/value here';
+	return 'Vendes Nigeria';
 }
 add_filter( 'login_headertitle', 'my_login_logo_url_title' );
 
-//remove back to website hyperlink
-p#backtoblog {
-  display: none;
-}
-
-//restrict jetpack for all user roles
+/**
+ * Restrict jetpack for all user roles.
+ */
 add_action( 'admin_init', 'restrict_page' );
 function restrict_page() {
-    if ( class_exists( 'Jetpack' ) && !current_user_can( 'manage_options' ) ) {
-        if ( isset( $_GET['page'] ) && $_GET['page'] == 'jetpack' ) {
-            wp_die( 'no access' );
-        }
-    }
+	if ( class_exists( 'Jetpack' ) && ! current_user_can( 'manage_options' ) ) {
+		if ( isset( $_GET['page'] ) && $_GET['page'] == 'jetpack' ) {
+			wp_die( 'no access' );
+		}
+	}
+}
+
+?>
+
+/*=== CSS ===*/
+
+/**
+* Remove back to website hyperlink.
+*/
+p#backtoblog {
+display: none;
 }

--- a/wordpress-hack-without-plugin.php
+++ b/wordpress-hack-without-plugin.php
@@ -82,7 +82,7 @@ return get_bloginfo( 'url' );
 add_filter( 'login_headerurl', 'my_login_logo_url' );
 
 function my_login_logo_url_title() {
-return 'Vendes Nigeria';
+return 'add_your_text/value here';
 }
 add_filter( 'login_headertitle', 'my_login_logo_url_title' );
 

--- a/wordpress-hack-without-plugin.php
+++ b/wordpress-hack-without-plugin.php
@@ -124,6 +124,10 @@ function restrict_page() {
 	}
 }
 
+/**
+ * Disable Editing in Dashboard (add to wp-config.php)
+ */
+define( 'DISALLOW_FILE_EDIT', true );
 ?>
 
 /*=== CSS ===*/


### PR DESCRIPTION
It would be good practice to encourage user of this repo to use suggesting [WordPress Standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/) formatting.

This also adds the option for disabling file edits by adding the `DISALLOW_FILE_EDIT` to `wp-config.php`.

References issue [#1](https://github.com/nnamddyy/wordpresshack/issues/1)